### PR TITLE
fixed compilation key error

### DIFF
--- a/include/testsuite.ch
+++ b/include/testsuite.ch
@@ -1,3 +1,6 @@
+#ifndef _TESTSUITE_CH
+#define _TESTSUITE_CH
+
 #xcommand TestSuite <cName> ;
     [ <description: Description> <cDesc> ] ;
     [ <verbose: Verbose> ] ;
@@ -31,8 +34,6 @@
     _ObjClassData( cDescription_Company, String, , <cCompany> ) ;;
     _ObjClassData( cDescription_Branch, String, , <cBranch> )
 
-
-
 #xcommand Feature <cFeat> ;
     TestSuite <cSuite> ;
     => ;
@@ -48,3 +49,20 @@
         oTester:lVerbose := __VERBOSE__ ;;
         oTester:Run( oTester ) ;;
         Return 0
+
+Static Function ReadFileContents( cFileName )
+    Local nHandler := FOpen( cFileName, FO_READWRITE + FO_SHARED )
+    Local nSize    := 0
+    Local xBuffer  := ''
+
+    If -1 == nHandler
+        Return Nil
+    EndIf
+
+    nSize := FSeek( nHandler, 0, FS_END )
+    FSeek( nHandler, 0 )
+    FRead( nHandler, xBuffer, nSize )
+    FClose( nHandler )
+    Return xBuffer
+
+#endif // _TESTSUITE_CH

--- a/src/fluentexpr.prw
+++ b/src/fluentexpr.prw
@@ -22,21 +22,6 @@ Static Function Format( cString, aValues )
     Next
     Return cResult
 
-Function ReadFileContents( cFileName )
-    Local nHandler := FOpen( cFileName, FO_READWRITE + FO_SHARED )
-    Local nSize    := 0
-    Local xBuffer  := ''
-
-    If -1 == nHandler
-        Return Nil
-    EndIf
-
-    nSize := FSeek( nHandler, 0, FS_END )
-    FSeek( nHandler, 0 )
-    FRead( nHandler, xBuffer, nSize )
-    FClose( nHandler )
-    Return xBuffer
-
 Class FluentExpr
     Data xValue
     Data lNot


### PR DESCRIPTION
the following error was returned during compilation

FLUENTEXPR.PRW(25)   Regular functions are not allowed in code.Use USER FUNCTION or STATIC FUNCTION at line 25.[Projeto: advpl-testsuite]
Chave de compilação não informada.

ReadFileContents was moved to testsuite.ch as a STATIC FUNCION

see issue #3 