### PR TITLE
Reduce verbosity

### DIFF
--- a/include/fluentexpr.ch
+++ b/include/fluentexpr.ch
@@ -1,0 +1,36 @@
+#xcommand Throw <cMsg> With <aValues> ;
+    => ;
+    __MSG__ := Format( <cMsg>, <aValues> ) ;;
+    aAdd( aTestReport, { .F., __MSG__ } ) ;;
+    UserException( __MSG__ ) ;;
+    Return Self
+
+#xcommand Passed <cMsg> With <aValues> ;
+    => ;
+    __MSG__ := Format( <cMsg>, <aValues> ) ;;
+    aAdd( aTestReport, { .T., __MSG__ } ) ;;
+    Return Self
+
+#xcommand Expect <prm,...> to [<not>] be <expr,...> ;
+     =>;
+     ::Expect(<prm>):[<Not>():]ToBe(<expr>)
+
+#xcommand Expect <prm,...> to [<not>] be a file ;
+     =>;
+     ::Expect(<prm>):[<Not>():]ToBeAFile()
+
+#xcommand Expect <prm,...> to [<not>] be a file with contents <expr,...> ;
+     =>;
+     ::Expect(<prm>):[<Not>():]ToBeAFileWithContents(<expr>)
+
+#xcommand Expect <prm,...> to [<not>] be a folder;
+     =>;
+     ::Expect(<prm>):[<Not>():]ToBeAFolder()
+
+#xcommand Expect <prm,...> to [<not>] have type <expr,...> ;
+     =>;
+     ::Expect(<prm>):[<Not>():]ToHaveType(<expr>)
+
+#xcommand Expect <prm,...> to [<not>] throw error;
+     =>;
+     ::Expect(<prm>):[<Not>():]ToThrowError(<expr>)

--- a/include/testsuite.ch
+++ b/include/testsuite.ch
@@ -1,6 +1,13 @@
 #ifndef _TESTSUITE_CH
 #define _TESTSUITE_CH
 
+#include 'fluentexpr.ch'
+
+#xcommand Test Suite <cDesc> [VERBOSE] => TestSuite SUITEID Description <cDesc> VERBOSE
+#xcommand End Test Suite => EndTestSuite ; CompileTestSuite SUITEID
+#xcommand Define Feature <cFeat> <cDesc> => Feature <cFeat> Description <cDesc> ; Feature <cFeat> TestSuite SUITEID
+#xcommand Define Before  => Enable Before ; Before TestSuite SUITEID
+
 #xcommand TestSuite <cName> ;
     [ <description: Description> <cDesc> ] ;
     [ <verbose: Verbose> ] ;
@@ -25,7 +32,7 @@
 
 #xcommand Enable Before ;
     => ;
-    _ObjClassMethod( Before, , )
+    _ObjClassMethod( Before, , ) 
 
 #xcommand Before TestSuite <cSuite> ;
     => ;

--- a/src/fluentexpr.prw
+++ b/src/fluentexpr.prw
@@ -1,19 +1,6 @@
 #include 'protheus.ch'
 #include 'testsuite.ch'
 
-#xcommand Throw <cMsg> With <aValues> ;
-    => ;
-    __MSG__ := Format( <cMsg>, <aValues> ) ;;
-    aAdd( aTestReport, { .F., __MSG__ } ) ;;
-    UserException( __MSG__ ) ;;
-    Return Self
-
-#xcommand Passed <cMsg> With <aValues> ;
-    => ;
-    __MSG__ := Format( <cMsg>, <aValues> ) ;;
-    aAdd( aTestReport, { .T., __MSG__ } ) ;;
-    Return Self
-
 Static Function Format( cString, aValues )
     Local cResult := cString
     Local nIndex
@@ -33,7 +20,7 @@ Static Function ToString( xValue )
     EndIf
     Return cValToChar( xValue )
 
-Class FluentExpr
+Class FluentExpr From LongNameClass
     Data xValue
     Data lNot
     Method New( xValue ) Constructor

--- a/tests/expect.prw
+++ b/tests/expect.prw
@@ -1,42 +1,40 @@
 #include 'protheus.ch'
 #include 'testsuite.ch'
 
-TestSuite Expect Description 'The test suite to test the test suite itself!' Verbose
-    Enable Environment 'T3' 'S SC 01'
-    Enable Before
-    Feature Files Description 'Tests with files should be working'
-    Feature Folders Description 'Tests with folders should be :top:'
-EndTestSuite
+#define SUITEID Expect
 
-Before TestSuite Expect
-    If File( '\love.txt' )
-        FErase( '\love.txt' )
-    EndIf
-    If ExistDir( '\problems' )
-        DirRemove( '\problems' )
-    EndIf
-    Return
+Test Suite 'The test suite to test the test suite itself!' Verbose
+    Define Before
+        If File( '\love.txt' )
+            FErase( '\love.txt' )
+        EndIf
+        If ExistDir( '\problems' )
+            DirRemove( '\problems' )
+        EndIf
+        Return
 
-Feature Files TestSuite Expect
-    Local nHandle
+    Define Feature Files 'Tests with files should be working'
+        Local nHandle
 
-    nHandle := FCreate( '\love.txt' )
-    FWrite( nHandle, 'I love you <3' )
-    FClose( nHandle )
+        nHandle := FCreate( '\love.txt' )
+        FWrite( nHandle, 'I love you <3' )
+        FClose( nHandle )
 
-    ::Expect( nHandle ):Not():ToHaveType( 'C' )
-    ::Expect( nHandle ):ToHaveType( 'N' )
-    ::Expect( nHandle ):Not():ToBe( 0 )
-    ::Expect( '\hate.txt' ):Not():ToBeAfile()
-    ::Expect( '\love.txt' ):ToBeAFile()
-    ::Expect( '\love.txt' ):Not():ToBeAFileWithContents( 'I hate you :@' )
-    ::Expect( '\love.txt' ):ToBeAFileWithContents( 'I love you <3+' )
-    Return
+        Expect nHandle to not have type 'C'
+        Expect nHandle to have type 'N'
+        Expect nHandle to not be 0
+        Expect '\hate.txt' to not be a file
+        Expect '\love.txt' to be a file
+        Expect '\love.txt' to not be a file with contents 'I hate you :@'
+        Expect '\love.txt' to be a file with contents 'I love you <3+'
+        Return
 
-Feature Folders TestSuite Expect
-    MakeDir( '\problems' )
-    ::Expect( '\problems' ):ToBeAFolder()
-    ::Expect( '\happiness' ):Not():ToBeAFolder()
-    Return
+    Define Feature Folders 'Tests with folders should be :top:'
+        MakeDir( '\problems' )
+        Expect '\problems' to be a folder
+        Expect '\happiness' to not be a folder
+        Return
 
-CompileTestSuite Expect
+End Test Suite
+
+#undef SUITEID


### PR DESCRIPTION
This PR introduces a less verbose way to create tests by creating a easier way to define a testsuite and a more natural way to express fluent expectations.

Old test definition:

``` xbase 
#include 'protheus.ch'
#include 'testsuite.ch'

TestSuite Expect Description 'The test suite to test the test suite itself!' Verbose
    Enable Environment 'T3' 'S SC 01'
    Enable Before
    Feature Files Description 'Tests with files should be working'
    Feature Folders Description 'Tests with folders should be :top:'
EndTestSuite

Before TestSuite Expect
    If File( '\love.txt' )
        FErase( '\love.txt' )
    EndIf
    If ExistDir( '\problems' )
        DirRemove( '\problems' )
    EndIf
    Return

Feature Files TestSuite Expect
    Local nHandle

    nHandle := FCreate( '\love.txt' )
    FWrite( nHandle, 'I love you <3' )
    FClose( nHandle )

    ::Expect( nHandle ):Not():ToHaveType( 'C' )
    ::Expect( nHandle ):ToHaveType( 'N' )
    ::Expect( nHandle ):Not():ToBe( 0 )
    ::Expect( '\hate.txt' ):Not():ToBeAfile()
    ::Expect( '\love.txt' ):ToBeAFile()
    ::Expect( '\love.txt' ):Not():ToBeAFileWithContents( 'I hate you :@' )
    ::Expect( '\love.txt' ):ToBeAFileWithContents( 'I love you <3+' )
    Return

Feature Folders TestSuite Expect
    MakeDir( '\problems' )
    ::Expect( '\problems' ):ToBeAFolder()
    ::Expect( '\happiness' ):Not():ToBeAFolder()
    Return

CompileTestSuite Expect

``` 

New test definition:

``` xbase
#define SUITEID Expect

Test Suite 'The test suite to test the test suite itself!' Verbose
    Define Before
        If File( '\love.txt' )
            FErase( '\love.txt' )
        EndIf
        If ExistDir( '\problems' )
            DirRemove( '\problems' )
        EndIf
        Return

    Define Feature Files 'Tests with files should be working'
        Local nHandle

        nHandle := FCreate( '\love.txt' )
        FWrite( nHandle, 'I love you <3' )
        FClose( nHandle )

        Expect nHandle to not have type 'C'
        Expect nHandle to have type 'N'
        Expect nHandle to not be 0
        Expect '\hate.txt' to not be a file
        Expect '\love.txt' to be a file
        Expect '\love.txt' to not be a file with contents 'I hate you :@'
        Expect '\love.txt' to be a file with contents 'I love you <3+'
        Return

    Define Feature Folders 'Tests with folders should be :top:'
        MakeDir( '\problems' )
        Expect '\problems' to be a folder
        Expect '\happiness' to not be a folder
        Return

End Test Suite

#undef SUITEID
```

I made it in a way it wouldn't affect existing tests but, if you like it, I can make it the only way to write the tests.