### PR TITLE
Changed AT Function to RAT on the search of source stack

### DIFF
--- a/src/testsuite.prw
+++ b/src/testsuite.prw
@@ -56,8 +56,8 @@ Static Function TryExtractSource( aStack, cResource )
 
     For nIndex := 1 To Len( aStack )
         If '(' $ aStack[ nIndex ] .And. '.PRW)' $ aStack[ nIndex ] .And. 'line : ' $ aStack[ nIndex ]
-            nPos := At( '(', aStack[ nIndex ] )
-            cStackFile := SubStr( aStack[ nIndex ], nPos + 1, At( ')', aStack[ nIndex ] ) - nPos - 1 )
+            nPos := RAt( '(', aStack[ nIndex ] )
+            cStackFile := SubStr( aStack[ nIndex ], nPos + 1, RAt( ')', aStack[ nIndex ] ) - nPos - 1 )
             If cStackFile == 'FLUENTEXPR.PRW' .Or. cStackFile == 'TESTSUITE.PRW'
                 Loop
             EndIf


### PR DESCRIPTION
The search with the function At returns the first statement of parentheses and maybe part of the message. Switching to the RAt function causes you to always search for the source name as expected because it will be at the end of the message.